### PR TITLE
feat: add quick submit

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,12 @@
 import Fuse from "fuse.js";
-import React, { ChangeEvent, FC, ReactNode, useRef, useState } from "react";
+import React, {
+  ChangeEvent,
+  FC,
+  KeyboardEvent,
+  ReactNode,
+  useRef,
+  useState,
+} from "react";
 import styled, { createGlobalStyle } from "styled-components";
 import Dropdown from "./dropdown";
 import useOutsideClick from "./hooks/use-outside-click";
@@ -212,6 +219,16 @@ const ReactSearchBox: FC<IProps> = ({
      * matches with the input, then that matched item appears in the dropdown.
      */
 
+    /**
+     * Enable quick trigger of `onSelect` by hitting `Enter` when there is only one found record displayed
+     */
+    const handleQuickSubmit = (e: KeyboardEvent) => {
+      if (matchedRecords.length === 1 && e.code === "Enter") {
+        e.preventDefault();
+        onSelect(matchedRecords[0]);
+      }
+    };
+
     return (
       <InputBox
         placeholder={placeholder}
@@ -227,6 +244,7 @@ const ReactSearchBox: FC<IProps> = ({
         inputBackgroundColor={inputBackgroundColor}
         leftIcon={leftIcon}
         iconBoxSize={iconBoxSize}
+        onKeyDown={handleQuickSubmit}
         type={type}
       />
     );

--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useEffect, useRef } from "react";
+import { FC, KeyboardEvent, ReactNode, useEffect, useRef } from "react";
 import {
   StyledInput,
   StyledIconContainer,
@@ -20,6 +20,7 @@ interface IProps {
   leftIcon?: ReactNode;
   iconBoxSize: number | string;
   type: string;
+  onKeyDown: (event: KeyboardEvent) => void;
 }
 
 const Input: FC<IProps> = ({
@@ -37,6 +38,7 @@ const Input: FC<IProps> = ({
   leftIcon,
   iconBoxSize,
   type,
+  onKeyDown,
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -76,6 +78,7 @@ const Input: FC<IProps> = ({
         inputBackgroundColor={inputBackgroundColor}
         leftIcon={leftIcon}
         iconBoxSize={iconBoxSize}
+        onKeyDown={onKeyDown}
       />
       {leftIconNode()}
     </StyledInputContainer>


### PR DESCRIPTION
Adds a way to trigger the `onSelect` function by simply hitting <kbd>Enter</kbd> when there is only one search record found. 

I found this to be an intuitive gesture that I would expect to be in place (i.e. that the search bar would do something when I submit). Maybe this is not the way to do this, though, and more customization should be added to allow users to specify another action to be triggered when hitting <kbd>Enter</kbd>.